### PR TITLE
Fixing reward function

### DIFF
--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -172,7 +172,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
             return -2.0
 
         # going fast close to the center of lane yeilds best reward
-        return 1.0 - (self.cte / self.max_cte) * self.speed
+        return (1.0 - (math.fabs(self.cte) / self.max_cte)) * self.speed
 
     ## ------ Socket interface ----------- ##
 


### PR DESCRIPTION
Reward function needed math.fabs for the absolute cte. Also needed parens, otherwise the rewards was backwards :)