### PR TITLE
Fix gym_donkeycar reset method is not well work.

### DIFF
--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -119,6 +119,9 @@ class DonkeyUnitySimHandler(IMesgHandler):
 
     def reset(self):
         logger.debug("reseting")
+        self.send_reset_car()
+        self.timer.reset()
+        time.sleep(1)
         self.image_array = np.zeros(self.camera_img_size)
         self.last_obs = self.image_array
         self.hit = "none"
@@ -128,9 +131,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.z = 0.0
         self.speed = 0.0
         self.over = False
-        self.send_reset_car()
-        self.timer.reset()
-        time.sleep(1)
+
 
     def get_sensor_size(self):
         return self.camera_img_size


### PR DESCRIPTION
gym_donkeycar reset method is not well work. After "done" is true, I run the reset method. then running "step" method return True. Because, After reset, gym_donkey get the old CTE value from DonkeySim.

Sample code is below.
```python
import gym
import gym_donkeycar


env = gym.make('donkey-generated-track-v0',exe_path='remote', host='127.0.0.1', port=9091, frame_skip=1)

if __name__ == '__main__':

    for i in range(0,10):

        env.reset()
        done = False
        while not done:
            _, _, done, i_e = env.step([0.0,1.0])
            print("{},{}.{}".format(i,done,i_e))
        _, _, done, i_e = env.step([0.0,0.0])
```
This is work around fix.