### PR TITLE
Improved tests

### DIFF
--- a/examples/genetic_alg/simple_gen_driver.py
+++ b/examples/genetic_alg/simple_gen_driver.py
@@ -189,14 +189,14 @@ class GeneticPositiveRewardAlg(GeneticAlg):
 
 if __name__ == "__main__":
 
-	# Initialize the donkey environment
+    # Initialize the donkey environment
     # where env_name one of:
     env_list = [
-       "donkey-warehouse-v0",
-       "donkey-generated-roads-v0",
-       "donkey-avc-sparkfun-v0",
-       "donkey-generated-track-v0",
-       "donkey-mountain-track-v0"
+        "donkey-warehouse-v0",
+        "donkey-generated-roads-v0",
+        "donkey-avc-sparkfun-v0",
+        "donkey-generated-track-v0",
+        "donkey-roboracingleague-track-v0"
     ]
 	
     parser = argparse.ArgumentParser(description='simple_gen_driver')
@@ -206,7 +206,7 @@ if __name__ == "__main__":
     parser.add_argument('--num_agents', type=int, default=8, help='how many agents in our population')
     parser.add_argument('--num_iter', type=int, default=8, help='how many generations before we stop')
     parser.add_argument('--max_steps', type=int, default=200, help='how many sim steps before we stop an epoch')
-    parser.add_argument('--env_name', type=str, default='donkey-mountain-track-v0', help='name of donkey sim environment', choices=env_list)
+    parser.add_argument('--env_name', type=str, default='donkey-warehouse-v0', help='name of donkey sim environment', choices=env_list)
     parser.add_argument('--in_model', type=str, help='.h5 model produced by donkeycar. expects the default linear model type.')
     parser.add_argument('--out_model', type=str,  default='out.h5', help='.h5 model to save.')
 

--- a/examples/gym_test.py
+++ b/examples/gym_test.py
@@ -17,9 +17,22 @@ NUM_EPISODES = 3
 MAX_TIME_STEPS = 1000
 
 
+def test_track(env_name, conf):
+    env = gym.make(env_name, conf=conf)
+
+    # make sure you have no track loaded
+    exit_scene(env)
+
+    simulate(env)
+
+    # exit the scene and close the env
+    exit_scene(env)
+    env.close()
+
+
 def select_action(env):
-    #return env.action_space.sample()
-    return [0.0, 0.1] # enable this to test checkpoint failure
+    return env.action_space.sample()  # taking random action from the action_space
+    # return [random.uniform(-1, 1), random.uniform(0, 1)]  # sending random steering and throttle
 
 
 def simulate(env):
@@ -33,6 +46,7 @@ def simulate(env):
 
             # Select an action
             action = select_action(env)
+            print(action)
 
             # execute the action
             obv, reward, done, info = env.step(action)
@@ -40,6 +54,10 @@ def simulate(env):
             if done:
                 print("done w episode.", info)
                 break
+
+
+def exit_scene(env):
+    env.viewer.exit_scene()
 
 
 if __name__ == "__main__":
@@ -51,7 +69,7 @@ if __name__ == "__main__":
         "donkey-generated-roads-v0",
         "donkey-avc-sparkfun-v0",
         "donkey-generated-track-v0",
-        "donkey-mountain-track-v0"
+        "donkey-roboracingleague-track-v0"
     ]
 
     parser = argparse.ArgumentParser(description='gym_test')
@@ -61,32 +79,35 @@ if __name__ == "__main__":
                         help='host to use for tcp')
     parser.add_argument('--port', type=int, default=9091,
                         help='port to use for tcp')
-    parser.add_argument('--env_name', type=str, default='donkey-mountain-track-v0',
-                        help='name of donkey sim environment', choices=env_list)
+    parser.add_argument('--env_name', type=str, default="all",
+                        help='name of donkey sim environment', choices=env_list+['all'])
 
     args = parser.parse_args()
 
-    conf = {"exe_path" : args.sim, 
-        "host" : args.host,
-        "port" : args.port,
+    conf = {
+        "exe_path": args.sim,
+        "host": args.host,
+        "port": args.port,
 
-        "body_style" : "donkey",
-        "body_rgb" : (128, 128, 128),
-        "car_name" : "me",
-        "font_size" : 100,
+        "body_style": "donkey",
+        "body_rgb": (128, 128, 128),
+        "car_name": "me",
+        "font_size": 100,
 
-        "racer_name" : "test",
-        "country" : "USA",
-        "bio" : "I am test client",
-        "guid" : str(uuid.uuid4()),
+        "racer_name": "test",
+        "country": "USA",
+        "bio": "I am test client",
+        "guid": str(uuid.uuid4()),
 
-        "max_cte" : 20,
-        }
+        "start_delay": 1,
+        "max_cte": 5,
+    }
 
-    env = gym.make(args.env_name, conf=conf)
-    
-    simulate(env)
+    if args.env_name == 'all':
+        for env_name in env_list:
+            test_track(env_name, conf)
 
-    env.close()
+    else:
+        test_track(args.env_name, conf)
 
     print("test finished")

--- a/examples/gym_test.py
+++ b/examples/gym_test.py
@@ -32,7 +32,6 @@ def test_track(env_name, conf):
 
 def select_action(env):
     return env.action_space.sample()  # taking random action from the action_space
-    # return [random.uniform(-1, 1), random.uniform(0, 1)]  # sending random steering and throttle
 
 
 def simulate(env):
@@ -46,7 +45,6 @@ def simulate(env):
 
             # Select an action
             action = select_action(env)
-            print(action)
 
             # execute the action
             obv, reward, done, info = env.step(action)

--- a/examples/reinforcement_learning/ddqn.py
+++ b/examples/reinforcement_learning/ddqn.py
@@ -333,13 +333,13 @@ def run_ddqn(args):
 if __name__ == "__main__":
 
     # Initialize the donkey environment
-    # where env_name one of:    
+    # where env_name one of:
     env_list = [
-       "donkey-warehouse-v0",
-       "donkey-generated-roads-v0",
-       "donkey-avc-sparkfun-v0",
-       "donkey-generated-track-v0"
-       "donkey-mountain-track-v0"
+        "donkey-warehouse-v0",
+        "donkey-generated-roads-v0",
+        "donkey-avc-sparkfun-v0",
+        "donkey-generated-track-v0",
+        "donkey-roboracingleague-track-v0"
     ]
 
     parser = argparse.ArgumentParser(description='ddqn')
@@ -348,11 +348,8 @@ if __name__ == "__main__":
     parser.add_argument('--test', action="store_true", help='agent uses learned model to navigate env')
     parser.add_argument('--port', type=int, default=9091, help='port to use for websockets')
     parser.add_argument('--throttle', type=float, default=0.3, help='constant throttle for driving')
-    parser.add_argument('--env_name', type=str, default='donkey-mountain-track-v0', help='name of donkey sim environment', choices=env_list)
+    parser.add_argument('--env_name', type=str, default='donkey-warehouse-v0', help='name of donkey sim environment', choices=env_list)
 
     args = parser.parse_args()
 
     run_ddqn(args)
-    
-
-

--- a/examples/reinforcement_learning/ppo_train.py
+++ b/examples/reinforcement_learning/ppo_train.py
@@ -36,22 +36,22 @@ def make_env(env_id, rank, seed=0):
 
 if __name__ == "__main__":
 
-	# Initialize the donkey environment
-    # where env_name one of:    
+    # Initialize the donkey environment
+    # where env_name one of:
     env_list = [
-       "donkey-warehouse-v0",
-       "donkey-generated-roads-v0",
-       "donkey-avc-sparkfun-v0",
-       "donkey-generated-track-v0",
-       "donkey-mountain-track-v0"
+        "donkey-warehouse-v0",
+        "donkey-generated-roads-v0",
+        "donkey-avc-sparkfun-v0",
+        "donkey-generated-track-v0",
+        "donkey-roboracingleague-track-v0"
     ]
-	
+
     parser = argparse.ArgumentParser(description='ppo_train')
     parser.add_argument('--sim', type=str, default="sim_path", help='path to unity simulator. maybe be left at manual if you would like to start the sim on your own.')
     parser.add_argument('--port', type=int, default=9091, help='port to use for tcp')
     parser.add_argument('--test', action="store_true", help='load the trained model and play')
     parser.add_argument('--multi', action="store_true", help='start multiple sims at once')
-    parser.add_argument('--env_name', type=str, default='donkey-mountain-track-v0', help='name of donkey sim environment', choices=env_list)
+    parser.add_argument('--env_name', type=str, default='donkey-warehouse-v0', help='name of donkey sim environment', choices=env_list)
     
     args = parser.parse_args()
 

--- a/examples/test_cam_config.py
+++ b/examples/test_cam_config.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         "donkey-generated-roads-v0",
         "donkey-avc-sparkfun-v0",
         "donkey-generated-track-v0",
-        "donkey-mountain-track-v0"
+        "donkey-roboracingleague-track-v0"
     ]
 
     parser = argparse.ArgumentParser(description='gym_test')
@@ -25,7 +25,7 @@ if __name__ == "__main__":
                         help='path to unity simulator. maybe be left at default if you would like to start the sim on your own.')
     parser.add_argument('--port', type=int, default=9091,
                         help='port to use for websockets')
-    parser.add_argument('--env_name', type=str, default='donkey-mountain-track-v0',
+    parser.add_argument('--env_name', type=str, default='donkey-warehouse-v0',
                         help='name of donkey sim environment', choices=env_list)
 
     args = parser.parse_args()

--- a/gym_donkeycar/envs/donkey_env.py
+++ b/gym_donkeycar/envs/donkey_env.py
@@ -43,7 +43,7 @@ class DonkeyEnv(gym.Env):
     STEER_LIMIT_LEFT = -1.0
     STEER_LIMIT_RIGHT = 1.0
     THROTTLE_MIN = 0.0
-    THROTTLE_MAX = 5.0
+    THROTTLE_MAX = 1.0
     VAL_PER_PIXEL = 255
 
     def __init__(self, level, conf):

--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -67,6 +67,9 @@ class DonkeyUnitySimContoller():
     def quit(self):
         self.client.stop()
 
+    def exit_scene(self):
+        self.handler.send_exit_scene()
+
     def render(self, mode):
         pass
 
@@ -324,7 +327,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
             if self.SceneToLoad in names:
                 self.send_load_scene(self.SceneToLoad)
             else:
-                raise ValueError("Scene name not in scene list")
+                raise ValueError(f"Scene name {self.SceneToLoad} not in scene list {names}")
 
     def send_control(self, steer, throttle):
         if not self.loaded:
@@ -343,6 +346,10 @@ class DonkeyUnitySimHandler(IMesgHandler):
 
     def send_load_scene(self, scene_name):
         msg = {'msg_type': 'load_scene', 'scene_name': scene_name}
+        self.queue_message(msg)
+
+    def send_exit_scene(self):
+        msg = {'msg_type': 'exit_scene'}
         self.queue_message(msg)
 
     def send_car_config(self, body_style, body_rgb, car_name, font_size):

--- a/tests/test_gym_donkeycar.py
+++ b/tests/test_gym_donkeycar.py
@@ -10,10 +10,11 @@ import gym
 import gym_donkeycar.envs
 
 env_list = [
-       "donkey-warehouse-v0",
-       "donkey-generated-roads-v0",
-       "donkey-avc-sparkfun-v0",
-       "donkey-generated-track-v0"
+    "donkey-warehouse-v0",
+    "donkey-generated-roads-v0",
+    "donkey-avc-sparkfun-v0",
+    "donkey-generated-track-v0",
+    "donkey-roboracingleague-track-v0"
 ]
 
 def test_load_gyms(mocker):


### PR DESCRIPTION
During some testing, I improved some areas that needed some refactor:
- action space on throttle didn't match real action space, it was : (0, 5) expected: (0, 1)
- gym_test.py can now run tests on the track name list (env_list), previously: 1 code start = 1 track test
- added to the handler a 'send_exit_scene' function to exit the scene and return to the main menu, used in the refactored gym_test.py script
