### PR TITLE
Failed install from git repository.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
+include gym_donkeycar/version.txt
 
 recursive-include tests *
 recursive-exclude * __pycache__


### PR DESCRIPTION
Below install command is failed. because MANIFEST.in file no include version.txt.  gym_donkeycar module load the version file.
```
pip install git+https://github.com/tawnkramer/gym-donkeycar 
```

I modified MANIFEST.in. Please check this pull request.

Best regard.