### PR TITLE
Update ddqn.py

### DIFF
--- a/examples/reinforcement_learning/ddqn.py
+++ b/examples/reinforcement_learning/ddqn.py
@@ -14,6 +14,7 @@ from collections import deque
 
 import cv2
 import gym
+import gym_donkeycar
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import backend as K


### PR DESCRIPTION
On my machine (Python 3.8 / gym_donkeycar '1.1.1'), i have to import gym_donkeycar to properly load the environment. without it, they are not properly registered. Cannot do the test alone as i have to update more line of code to make it work with TensorFlow 2.5.