### PR TITLE
Added a lap counter to the info dictionary returned by the gym.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,9 +47,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"DonkeyCar OpenAI Gym"
-copyright = u"2019, Leigh Johnson"
-author = u"Leigh Johnson"
+project = "DonkeyCar OpenAI Gym"
+copyright = "2019, Leigh Johnson"
+author = "Leigh Johnson"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -125,7 +125,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "gym_donkeycar.tex", u"OpenAI Gym Environments for Donkey CarDocumentation", u"Leigh Johnson", "manual")
+    (master_doc, "gym_donkeycar.tex", "OpenAI Gym Environments for Donkey CarDocumentation", "Leigh Johnson", "manual")
 ]
 
 
@@ -133,7 +133,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "gym_donkeycar", u"OpenAI Gym Environments for Donkey CarDocumentation", [author], 1)]
+man_pages = [(master_doc, "gym_donkeycar", "OpenAI Gym Environments for Donkey CarDocumentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -145,7 +145,7 @@ texinfo_documents = [
     (
         master_doc,
         "gym_donkeycar",
-        u"OpenAI Gym Environments for Donkey CarDocumentation",
+        "OpenAI Gym Environments for Donkey CarDocumentation",
         author,
         "gym_donkeycar",
         "One line description of project.",

--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -140,6 +140,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.last_lap_time = 0.0
         self.current_lap_time = 0.0
         self.starting_line_index = -1
+        self.lap_count = 0
 
     def on_connect(self, client):
         logger.debug("socket connected")
@@ -165,6 +166,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
             time_at_crossing = message["timeStamp"]
             self.last_lap_time = float(time_at_crossing - self.current_lap_time)
             self.current_lap_time = time_at_crossing
+            self.lap_count += 1
             lap_msg = f"New lap time: {round(self.last_lap_time, 2)} seconds"
             logger.info(lap_msg)
 
@@ -369,6 +371,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.lidar = []
         self.current_lap_time = 0.0
         self.last_lap_time = 0.0
+        self.lap_count = 0
 
         # car
         self.roll = 0.0
@@ -401,6 +404,7 @@ class DonkeyUnitySimHandler(IMesgHandler):
             "lidar": (self.lidar),
             "car": (self.roll, self.pitch, self.yaw),
             "last_lap_time": self.last_lap_time,
+            "lap_count": self.lap_count,
         }
 
         # Add the second image to the dict


### PR DESCRIPTION
In trying to create a more automated testing tool, I wanted to be able to count laps completed and none of the existing code seemed to work. See this commit for an example of how I'm using it: https://github.com/Bleyddyn/malpi/commit/e7d2c43a840e3d9260cfd65a062e1bcddb9bbdb4

I don't see any way to create issues on this repo, so I'm just doing a pull request. If there's someplace I should add documentation about the change, let me know.