### PR TITLE
Include lap time in reward function

### DIFF
--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -427,6 +427,8 @@ class DonkeyUnitySimHandler(IMesgHandler):
         self.current_lap_time = 0.0
         self.last_lap_time = 0.0
         self.lap_count = 0
+        self.num_lap_bonuses_collected = 0
+        self.bonus_coeff = 1e4 # scaling factor for the bonus reward to encourage minimizing lap times
 
         # car
         self.roll = 0.0
@@ -487,16 +489,21 @@ class DonkeyUnitySimHandler(IMesgHandler):
         # Normalization factor, real max speed is around 30
         # but only attained on a long straight line
         # max_speed = 10
+        reward = 0.0
 
+        if self.lap_count > self.num_lap_bonuses_collected:
+            self.num_lap_bonuses_collected += 1
+            reward += bonus_coeff / self.last_lap_time
+        
         if done:
-            return -1.0
+            return reward - 1.0
 
         if self.cte > self.max_cte:
-            return -1.0
+            return reward - 1.0
 
         # Collision
         if self.hit != "none":
-            return -2.0
+            return reward - 2.0
 
         # going fast close to the center of lane yeilds best reward
         if self.forward_vel > 0.0:

--- a/gym_donkeycar/envs/donkey_sim.py
+++ b/gym_donkeycar/envs/donkey_sim.py
@@ -507,10 +507,10 @@ class DonkeyUnitySimHandler(IMesgHandler):
 
         # going fast close to the center of lane yeilds best reward
         if self.forward_vel > 0.0:
-            return (1.0 - (math.fabs(self.cte) / self.max_cte)) * self.forward_vel
+            return reward + (1.0 - (math.fabs(self.cte) / self.max_cte)) * self.forward_vel
 
         # in reverse, reward doesn't have centering term as this can result in some exploits
-        return self.forward_vel
+        return reward + self.forward_vel
 
     # ------ Socket interface ----------- #
 


### PR DESCRIPTION
Hey there,

I ran some experiments with RL and wondered why the reward function does not directly depend on the lap time. I think it makes a lot of sense to shape the reward to encourage staying in the center and driving with high velocity. However, to get a racing policy that sometimes intentionally breaks these rules (e.g. doesn't stay in the center to take a curve optimally) to really optimize the lap time, I think the reward function should include the lap time in the reward calculation (give a bonus for low lap times).

I've added an idea on how to implement this in the attached commit. Here, an additional reward is given that is inversely correlated to the lap time (high lap time = low reward, low lap time = high reward). It can be scaled with a factor that weights this additional reward versus the other rewards. This factor is currently just eyeballed and probably needs to be tuned for optimal results. But even with the current form, it yielded pretty good experimental results.

Link to a video with a trained PPO (the simulator is set to 4x speed and max. throttle=0.4; PPO is trained without action smoothing and without frame stacking - so just a really simple baseline): https://drive.google.com/file/d/1Ucsrfwqm02PzzJlb76ozMVTX_tqMiIjE/view?usp=sharing

Eager to hear what you think.
Best, Till